### PR TITLE
{bz: 4953}: Unbreak Google Chrome 9

### DIFF
--- a/socialcalctableeditor.js
+++ b/socialcalctableeditor.js
@@ -5924,13 +5924,20 @@ SocialCalc.KeyboardSetFocus = function(editor) {
          }
       SocialCalc.Keyboard.passThru = null;
       }
-   window.focus();
+
+      switch (typeof window.focus) {
+         case 'function': { window.focus(); break; }
+         case 'boolean': { window.focus = true; break; }
+         }
    }
 
 SocialCalc.KeyboardFocus = function() {
 
    SocialCalc.Keyboard.passThru = null;
-   window.focus();
+      switch (typeof window.focus) {
+         case 'function': { window.focus(); break; }
+         case 'boolean': { window.focus = true; break; }
+         }
 
    }
 


### PR DESCRIPTION
Google Chrome 9 changed the definition to window.focus to be a boolean - here's the fix. :-)
